### PR TITLE
Fixed Typo in pragma mark

### DIFF
--- a/ZCAnimatedLabel/ZCAnimatedLabel/ZCAnimatedLabel.m
+++ b/ZCAnimatedLabel/ZCAnimatedLabel/ZCAnimatedLabel.m
@@ -192,7 +192,7 @@
     }
 }
 
-#pragma Label related
+#pragma mark Label related
 
 - (void) setNeedsDisplayInRect:(CGRect)rect
 {


### PR DESCRIPTION
Just fixed a typo in pragma mark annotation
